### PR TITLE
232175: Bug fix to have Allowed Values for template parameters

### DIFF
--- a/templates/pipelines/common-infrastructure-deploy.yaml
+++ b/templates/pipelines/common-infrastructure-deploy.yaml
@@ -95,15 +95,9 @@ stages:
                           scriptPath: templates/powershell/Build-BicepTemplate.ps1
                           ${{ if eq(parameters.acrServiceConnection, '') }}:
                             Type: PowerShell
-                          ${{ if ne(template.parameterFilePath, '') }}:
-                            scriptArguments: >
-                              -TemplateName "${{ template.name }}"
-                              -TemplatePath "$(Pipeline.Workspace)/s/self/${{ template.path }}"
-                              -parameterFilePath "$(Build.SourcesDirectory)/self/${{ template.parameterFilePath }}"
-                          ${{ else }}:
-                            scriptArguments: >
-                              -TemplateName "${{ template.name }}"
-                              -TemplatePath "$(Pipeline.Workspace)/s/self/${{ template.path }}"
+                          scriptArguments: >
+                            -TemplateName "${{ template.name }}"
+                            -TemplatePath "$(Pipeline.Workspace)/s/self/${{ template.path }}"
                       
                       - displayName: ARM ttk - ${{ template.name }}
                         scriptRepo: PipelineCommonFiles

--- a/templates/powershell/Build-BicepTemplate.ps1
+++ b/templates/powershell/Build-BicepTemplate.ps1
@@ -55,19 +55,19 @@ try {
     [string]$command = "az bicep build --file $TemplatePath/$TemplateName.bicep"
     Invoke-CommandLine -Command $command
     if ($ParameterFilePath -and $(Test-Path $ParameterFilePath)) {
-        $parameterFile = Join-Path -Path $ParameterFilePath -ChildPath "$TemplateName.bicepparam"
+        $parameterFile = Join-Path -Path $ParameterFilePath -ChildPath "$TemplateName.transformed.bicepparam"
         
         Write-Debug "Building Bicep params $parameterFile"
-        $command = "az bicep build-params --file $parameterFile --outfile $ParameterFilePath/$TemplateName.parameters.json"
+        $command = "az bicep build-params --file $parameterFile --outfile $ParameterFilePath/$TemplateName.transformed.parameters.json"
         Invoke-CommandLine -Command $command
     }
     else {
-        $parameterFile = Join-Path -Path $TemplatePath -ChildPath "$TemplateName.bicepparam"
+        $parameterFile = Join-Path -Path $TemplatePath -ChildPath "$TemplateName.transformed.bicepparam"
         Write-Debug $parameterFile
     
         if (Test-Path $parameterFile -PathType Leaf) {
             Write-Debug "Building Bicep params $parameterFile"
-            $command = "az bicep build-params --file $parameterFile --outfile $TemplatePath/$TemplateName.parameters.json"
+            $command = "az bicep build-params --file $parameterFile --outfile $TemplatePath/$TemplateName.transformed.parameters.json"
             Invoke-CommandLine -Command $command
         }
     }

--- a/templates/powershell/Build-BicepTemplate.ps1
+++ b/templates/powershell/Build-BicepTemplate.ps1
@@ -7,10 +7,8 @@ Compiles Bicep template and bicepparam files to json templates
 Mandatory. Template file name.
 .PARAMETER TemplatePath
 Mandatory. Template folder path.
-.PARAMETER ParameterFilePath
-Optional. Parameter file folder name.
 .EXAMPLE
-.\Template-Deployment.ps1 -TemplateName <TemplateName> -TemplatePath <TemplatePath> -ParameterFilePath <ParameterFilePath>
+.\Template-Deployment.ps1 -TemplateName <TemplateName> -TemplatePath <TemplatePath>
 #>
 [CmdletBinding()]
 Param
@@ -19,8 +17,6 @@ Param
     [string]$TemplateName,
     [Parameter(Mandatory)]
     [string]$TemplatePath,
-    [Parameter()]
-    [string]$ParameterFilePath = '',
     [Parameter()]
     [string]$WorkingDirectory = $PWD
 )
@@ -45,7 +41,6 @@ if ($enableDebug) {
 Write-Host "${functionName} started at $($startTime.ToString('u'))"
 Write-Debug "${functionName}:TemplateName=$TemplateName"
 Write-Debug "${functionName}:TemplatePath=$TemplatePath"
-Write-Debug "${functionName}:ParameterFilePath=$ParameterFilePath"
 
 try {
     [System.IO.DirectoryInfo]$moduleDir = Join-Path -Path $WorkingDirectory -ChildPath "templates/powershell/modules/ps-helpers"
@@ -54,23 +49,6 @@ try {
 
     [string]$command = "az bicep build --file $TemplatePath/$TemplateName.bicep"
     Invoke-CommandLine -Command $command
-    if ($ParameterFilePath -and $(Test-Path $ParameterFilePath)) {
-        $parameterFile = Join-Path -Path $ParameterFilePath -ChildPath "$TemplateName.transformed.bicepparam"
-        
-        Write-Debug "Building Bicep params $parameterFile"
-        $command = "az bicep build-params --file $parameterFile --outfile $ParameterFilePath/$TemplateName.transformed.parameters.json"
-        Invoke-CommandLine -Command $command
-    }
-    else {
-        $parameterFile = Join-Path -Path $TemplatePath -ChildPath "$TemplateName.transformed.bicepparam"
-        Write-Debug $parameterFile
-    
-        if (Test-Path $parameterFile -PathType Leaf) {
-            Write-Debug "Building Bicep params $parameterFile"
-            $command = "az bicep build-params --file $parameterFile --outfile $TemplatePath/$TemplateName.transformed.parameters.json"
-            Invoke-CommandLine -Command $command
-        }
-    }
     $exitCode = 0
 }
 catch {


### PR DESCRIPTION
## Bug fix to have allowed values for template parameters

Change the bicep build scripts to remove the parameter file transformation as are not using the transformed parameter file anywhere in the process.

Work Item: AB#232175