### PR TITLE
261143: ServiceNamer Paramater fix in script

### DIFF
--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -200,6 +200,7 @@ stages:
                 -KeyVaultVSecretNames '${{ convertToJson(parameters.appDeployConfig.variables) }}' 
                 -InfraChartHomeDir '$(Pipeline.Workspace)/s/helm/${{ parameters.serviceName }}-infra'
                 -PSHelperDirectory ${{ variables.PSHelperDirectory }}
+                -ServiceName ${{ parameters.serviceName }}
               workingDirectory: $(Pipeline.Workspace)/s      
 
           - task: AzureCLI@2

--- a/templates/powershell/build/Build-Helm-KVSecretsRoleAssignments.ps1
+++ b/templates/powershell/build/Build-Helm-KVSecretsRoleAssignments.ps1
@@ -13,7 +13,7 @@ Mandatory. Service Name
 .PARAMETER PSHelperDirectory
 Mandatory. Directory Path of PSHelper module
 .EXAMPLE
-.\Build-Helm-KVSecretsRoleAssignments.ps1 -KeyVaultVSecretNames <KeyVaultVSecretNames> -InfraChartHomeDir <InfraChartHomeDir> -PSHelperDirectory <PSHelperDirectory>
+.\Build-Helm-KVSecretsRoleAssignments.ps1 -KeyVaultVSecretNames <KeyVaultVSecretNames> -InfraChartHomeDir <InfraChartHomeDir> -ServiceName <ServiceName> -PSHelperDirectory <PSHelperDirectory>
 #> 
 
 [CmdletBinding()]
@@ -48,6 +48,7 @@ if ($enableDebug) {
 Write-Host "${functionName} started at $($startTime.ToString('u'))"
 Write-Debug "${functionName}:KeyVaultVSecretNames=$KeyVaultVSecretNames"
 Write-Debug "${functionName}:InfraChartHomeDir=$InfraChartHomeDir"
+Write-Debug "${functionName}:ServiceName=$ServiceName"
 Write-Debug "${functionName}:PSHelperDirectory=$PSHelperDirectory"
 
 try {

--- a/templates/powershell/build/Build-Helm-KVSecretsRoleAssignments.ps1
+++ b/templates/powershell/build/Build-Helm-KVSecretsRoleAssignments.ps1
@@ -8,6 +8,8 @@ Adds keyvault-secrets-role-assignment.yaml template to Infra Helm chart folder a
 Mandatory. Keyvault Secret Names in string format
 .PARAMETER InfraChartHomeDir
 Mandatory. Directory Path of Infra Chart HomeDirectory
+.PARAMETER ServiceName
+Mandatory. Service Name
 .PARAMETER PSHelperDirectory
 Mandatory. Directory Path of PSHelper module
 .EXAMPLE
@@ -21,9 +23,9 @@ param(
     [Parameter(Mandatory)]
     [string] $InfraChartHomeDir,
     [Parameter(Mandatory)]
-    [string]$PSHelperDirectory,
+    [string]$ServiceName,
     [Parameter(Mandatory)]
-    [string]$ServiceName
+    [string]$PSHelperDirectory
 )
 
 Set-StrictMode -Version 3.0

--- a/templates/powershell/build/Build-Helm-KVSecretsRoleAssignments.ps1
+++ b/templates/powershell/build/Build-Helm-KVSecretsRoleAssignments.ps1
@@ -21,7 +21,9 @@ param(
     [Parameter(Mandatory)]
     [string] $InfraChartHomeDir,
     [Parameter(Mandatory)]
-    [string]$PSHelperDirectory
+    [string]$PSHelperDirectory,
+    [Parameter(Mandatory)]
+    [string]$ServiceName
 )
 
 Set-StrictMode -Version 3.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
Added ServiceNamer parameter to Build-Helm-KVSecretsRoleAssignments script
[AB#261143](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/261143)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [x] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
