### PR TITLE
306948: Fix for pwsh task in appconfig-import

### DIFF
--- a/templates/steps/appconfig-import.yaml
+++ b/templates/steps/appconfig-import.yaml
@@ -29,7 +29,7 @@ steps:
   - ${{ if ne(parameters.appDeployConfig, '') }}:          
     - pwsh: |
         $PSVersionTable
-        sudo apt-get install -y powershell=7.4.0-1.deb
+        sudo apt-get install -y powershell=7.4.0-1.deb --allow-downgrades
       errorActionPreference: silentlyContinue
       displayName: 'Upgrade PowerShell Version'  
     - task: PowerShell@2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
This PR contains the changes to fix CI pipeline failing on appconfig-import
- Added --allow-downgrades flag on pwsh task in appconfig-import

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
![image](https://github.com/DEFRA/ado-pipeline-common/assets/119388966/a90d7928-fbdf-4908-9875-4380bf22f7c6)


# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
