### PR TITLE
366087: Helm Publish bug fix

### DIFF
--- a/templates/powershell/build/HelmLintAndPublish.ps1
+++ b/templates/powershell/build/HelmLintAndPublish.ps1
@@ -70,11 +70,14 @@ function Update-KVSecretValues {
         $valuesYamlPath = "$InfraChartHomeDir\values.yaml"
         [string]$content = Get-Content -Raw -Path $valuesYamlPath
         Write-Debug "$valuesYamlPath content before: $content"
-        if ($content) {
-            $valuesObject = ConvertFrom-YAML $content -Ordered            
+        if($content) {
+            $valuesObject = ConvertFrom-YAML $content -Ordered
+            # This condition is to initialize '$valuesObject' when values.yaml files contains only comments and not any values(Possible scenario).
+            if(-not $valuesObject) {
+                $valuesObject = [ordered]@{}
+            }
         }
-        # if there are no values except some comments in the file
-        if (!$valuesObject) {
+        else {
             $valuesObject = [ordered]@{}
         }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
Helm Publish bug fix - Added condition to handle empty values.yaml or values.yaml file with only comments in it.
Relates to ADO Work Item [AB#366087](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/366087)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=534963&view=logs&j=c4455180-6351-58ac-f388-f78c673f88c7&t=08f836ba-c389-5465-aebc-0b67cd507da0

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
