### PR TITLE
353142: Add token replace step for type script

### DIFF
--- a/templates/pipelines/common-infrastructure-deploy.yaml
+++ b/templates/pipelines/common-infrastructure-deploy.yaml
@@ -334,6 +334,11 @@ stages:
                                       scriptsList: ${{ deployment.postDeployScriptsList }}
                                       variables: ${{ variables }}
                               - ${{ if eq(deployment.type, 'script') }}:
+                                - template: /templates/steps/initialize.yaml
+                                  parameters:
+                                    additionalRepositories: ${{ parameters.additionalRepositories }}
+                                    tokenReplaceLocations: ${{ parameters.filePathsForTransform }}
+                                    tokenReplaceEscapeConfig: ${{ parameters.tokenReplaceEscapeConfig }}
                                 - template: /templates/steps/powershell.yaml
                                   parameters:
                                     azureResourceManagerConnection: "${{ coalesce(variables[deployment.serviceConnectionVariableName], env.serviceConnection) }}"


### PR DESCRIPTION
During creation of app registrations when we were trying to pass a value from a Powershell script to the App Registration script, we noticed the token replacement wasn't happening between the scripts.  We have added the token replacement step for the 'script' type to allow for token replacement correctly between 2 scripts.

[AB#353142](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/353142)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*
Successful pipeline run when creating a App Registrations.

https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=546439&view=logs&j=4c883f62-4b34-5db3-298a-543e53f2099b&t=1162edb1-1257-5165-acc9-be782580940b


# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
