### PR TITLE
372726: Fix Tag to lower for ACR Import Bug

### DIFF
--- a/templates/powershell/build/BuildAndPushDockerImage.ps1
+++ b/templates/powershell/build/BuildAndPushDockerImage.ps1
@@ -187,7 +187,7 @@ try {
     #Application Image
     [string]$AcrName = $AcrName.ToLower()
     Write-Host "Processing Application Docker file: Dockerfile"
-    [string]$tagName = $AcrRepoName + ":" + $ImageVersion
+    [string]$tagName = $AcrRepoName.ToLower() + ":" + $ImageVersion
     [string]$AcrtagName = $AcrName + ".azurecr.io/image/" + $tagName
     Write-Debug "${functionName}:Docker Image=$tagName"
     Write-Debug "${functionName}:AcrtagName=$AcrtagName"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
We have an issue on build for ACR Tags whereby we need to force ToLower the name for Azure to accept it. This PR does that.

#AB372726

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
