### PR TITLE
353142: Added job to check for flux deployment completion

### DIFF
--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -451,15 +451,15 @@ stages:
                             PSHelperDirectory: ${{ variables.PSHelperDirectory }}
                             stepsToSkip: ${{ parameters.stepsToSkip }}
 
-                        - task: PowerShell@2
-                          displayName: 'Set Image added to ACR time used to check Flux Helm Release'   
-                          inputs:
-                            targetType: inline
-                            script: |
-                              Write-Host "##vso[task.setvariable variable=acrImageAddedTime]$(Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ')"
-                            failOnStderr: false
-                            pwsh: true
-                            workingDirectory: '$(Pipeline.Workspace)/s' 
+                      - task: PowerShell@2
+                        displayName: 'Set Image added to ACR time used to check Flux Helm Release'   
+                        inputs:
+                          targetType: inline
+                          script: |
+                            Write-Host "##vso[task.setvariable variable=acrImageAddedTime]$(Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ')"
+                          failOnStderr: false
+                          pwsh: true
+                          workingDirectory: '$(Pipeline.Workspace)/s' 
 
                       - ${{ if and(eq(deploymentEnv.name, parameters.appTestConfig.postDeployTest.envToTest),not(contains(parameters.stepsToSkip, 'PostDeploymentTests'))) }}:
                         - template: /templates/steps/post-deployment-tests.yaml

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -476,15 +476,6 @@ stages:
               variables:
                 - name: helmImageAddedToACRTime
                   value: $[ dependencies.PublishTo${{ deploymentEnv.name }}.outputs['PublishTo${{ deploymentEnv.name }}.setAcrImageAddedTime.acrImageAddedTime']]
-                # - ${{ if eq(deploymentEnv.name, 'snd1') }}:
-                #   - name: callBackServiceConnection
-                #     value: 'AZD-ADP-FluxDeploymentApi-DEV1'
-                # - ${{ elseif in(deploymentEnv.name, 'snd2', 'snd3') }}:
-                #   - name: callBackServiceConnection
-                #     value: 'AZD-ADP-FluxDeploymentApi-TST'
-                # - ${{ elseif in(deploymentEnv.name, 'dev1', 'tst1', 'pre1', 'prd1') }}:
-                #   - name: callBackServiceConnection
-                #     value: 'AZD-ADP-FluxDeploymentApi-PRD'
               timeoutInMinutes: 10
               steps:            
                 - task: InvokeRESTAPI@1

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -450,24 +450,25 @@ stages:
                             appDeployConfig: ${{ parameters.appDeployConfig }}
                             PSHelperDirectory: ${{ variables.PSHelperDirectory }}
                             stepsToSkip: ${{ parameters.stepsToSkip }}
-
-                      - task: PowerShell@2
-                        displayName: 'Set Image added to ACR time used to check Flux Helm Release'
-                        name: setAcrImageAddedTime
-                        inputs:
-                          targetType: inline
-                          script: |
-                            Write-Host "##vso[task.setvariable variable=acrImageAddedTime;isOutput=true;]$(Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ')"
-                          failOnStderr: false
-                          pwsh: true
-                          workingDirectory: '$(Pipeline.Workspace)/s' 
+                      
+                      - ${{ if eq(deploymentEnv.adoCallBackApiEnabled, True) }}:
+                        - task: PowerShell@2
+                          displayName: 'Set Image added to ACR time used to check Flux Helm Release'
+                          name: setAcrImageAddedTime
+                          inputs:
+                            targetType: inline
+                            script: |
+                              Write-Host "##vso[task.setvariable variable=acrImageAddedTime;isOutput=true;]$(Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ')"
+                            failOnStderr: false
+                            pwsh: true
+                            workingDirectory: '$(Pipeline.Workspace)/s' 
 
                       - ${{ if and(eq(deploymentEnv.name, parameters.appTestConfig.postDeployTest.envToTest),not(contains(parameters.stepsToSkip, 'PostDeploymentTests'))) }}:
                         - template: /templates/steps/post-deployment-tests.yaml
                           parameters:
                             url: "${{ parameters.serviceName }}.${{ deploymentEnv.name }}.${{ parameters.appTestConfig.postDeployTest.domain }}"
           
-          - ${{ if eq(deploymentEnv.name, 'snd1') }}: # Need to add other environments (snd2, snd3, dev1, tst1, pre1, prd1) incrementally as and when the Flux Notifications solution is ready in those environments.
+          - ${{ if eq(deploymentEnv.adoCallBackApiEnabled, True) }}:
             - job: WaitForFluxRelease
               displayName: 'Wait For Flux Release'
               dependsOn: PublishTo${{ deploymentEnv.name }}
@@ -475,21 +476,21 @@ stages:
               variables:
                 - name: helmImageAddedToACRTime
                   value: $[ dependencies.PublishTo${{ deploymentEnv.name }}.outputs['PublishTo${{ deploymentEnv.name }}.setAcrImageAddedTime.acrImageAddedTime']]
-                - ${{ if eq(deploymentEnv.name, 'snd1') }}:
-                  - name: callBackServiceConnection
-                    value: 'AZD-ADP-FluxDeploymentApi-DEV1'
-                - ${{ elseif in(deploymentEnv.name, 'snd2', 'snd3') }}:
-                  - name: callBackServiceConnection
-                    value: 'AZD-ADP-FluxDeploymentApi-TST'
-                - ${{ elseif in(deploymentEnv.name, 'dev1', 'tst1', 'pre1', 'prd1') }}:
-                  - name: callBackServiceConnection
-                    value: 'AZD-ADP-FluxDeploymentApi-PRD'
+                # - ${{ if eq(deploymentEnv.name, 'snd1') }}:
+                #   - name: callBackServiceConnection
+                #     value: 'AZD-ADP-FluxDeploymentApi-DEV1'
+                # - ${{ elseif in(deploymentEnv.name, 'snd2', 'snd3') }}:
+                #   - name: callBackServiceConnection
+                #     value: 'AZD-ADP-FluxDeploymentApi-TST'
+                # - ${{ elseif in(deploymentEnv.name, 'dev1', 'tst1', 'pre1', 'prd1') }}:
+                #   - name: callBackServiceConnection
+                #     value: 'AZD-ADP-FluxDeploymentApi-PRD'
               timeoutInMinutes: 10
               steps:            
                 - task: InvokeRESTAPI@1
                   displayName: 'Call ADO controller api to check If Helmrelease is successfull'
                   inputs:
-                    serviceConnection: '${{ variables.callBackServiceConnection }}'
+                    serviceConnection: 'AZD-ADP-FluxDeploymentApi-${{ deploymentEnv.adoCallBackApiEnabledEnv }}'
                     urlSuffix: 'api/AdoTask/execute'
                     method: POST
                     body: |
@@ -501,9 +502,3 @@ stages:
                       "helmImageAddedToACRTime": "$(helmImageAddedToACRTime)"
                       }
                     waitForCompletion: 'true'
-            
-            # - job: Post Deployment Tests
-            #   displayName: 'Post Deployment Tests'
-            #   dependsOn: WaitForFluxRelease
-            #   steps:
-            #   - bash: echo "Running Post Deployment Tests"

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -455,3 +455,29 @@ stages:
                         - template: /templates/steps/post-deployment-tests.yaml
                           parameters:
                             url: "${{ parameters.serviceName }}.${{ deploymentEnv.name }}.${{ parameters.appTestConfig.postDeployTest.domain }}"
+
+          - job: WaitForFluxRelease
+            displayName: 'Wait For Flux Release'
+            dependsOn: PublishTo${{ deploymentEnv.name }}
+            pool: server
+            timeoutInMinutes: 10
+            steps:            
+              - task: InvokeRESTAPI@1
+                displayName: 'Call ADO controller api to check If Helmrelease is successfull'
+                inputs:
+                  serviceConnection: 'AZD-ADP-FluxDeploymentApi-DEV1'
+                  urlSuffix: 'api/AdoTask'
+                  method: POST
+                  body: |
+                    {
+                    "serviceName": "${{ parameters.serviceName }}",
+                    "helmReleaseName": "${{ parameters.serviceName }}",
+                    "helmReleaseVersion": $(appVersion),
+                    "environment": "snd"
+                    }
+                  waitForCompletion: 'true'
+          
+          - job: PostDeploymentTests
+            dependsOn: WaitForFluxRelease
+            steps:
+            - bash: echo "Running Post Deployment Tests"

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -483,7 +483,7 @@ stages:
                     "serviceName": "${{ parameters.serviceName }}",
                     "helmReleaseName": "${{ parameters.serviceName }}",
                     "helmReleaseVersion": "$(appVersion)",
-                    "environment": "snd"
+                    "environment": "${{ deploymentEnv.name}}"
                     }
                   waitForCompletion: 'true'
           

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -466,43 +466,44 @@ stages:
                         - template: /templates/steps/post-deployment-tests.yaml
                           parameters:
                             url: "${{ parameters.serviceName }}.${{ deploymentEnv.name }}.${{ parameters.appTestConfig.postDeployTest.domain }}"
-
-          - job: WaitForFluxRelease
-            displayName: 'Wait For Flux Release'
-            dependsOn: PublishTo${{ deploymentEnv.name }}
-            pool: server
-            variables:
-              - name: helmImageAddedToACRTime
-                value: $[ dependencies.PublishTo${{ deploymentEnv.name }}.outputs['PublishTo${{ deploymentEnv.name }}.setAcrImageAddedTime.acrImageAddedTime']]
-              - ${{ if eq(deploymentEnv.name, 'snd1') }}:
-                - name: callBackServiceConnection
-                  value: 'AZD-ADP-FluxDeploymentApi-DEV1'
-              - ${{ elseif in(deploymentEnv.name, 'snd2', 'snd3') }}:
-                - name: callBackServiceConnection
-                  value: 'AZD-ADP-FluxDeploymentApi-TST'
-              - ${{ elseif in(deploymentEnv.name, 'dev1', 'tst1', 'pre1', 'prd1') }}:
-                - name: callBackServiceConnection
-                  value: 'AZD-ADP-FluxDeploymentApi-PRD'
-            timeoutInMinutes: 10
-            steps:            
-              - task: InvokeRESTAPI@1
-                displayName: 'Call ADO controller api to check If Helmrelease is successfull'
-                inputs:
-                  serviceConnection: '${{ variables.callBackServiceConnection }}'
-                  urlSuffix: 'api/AdoTask/execute'
-                  method: POST
-                  body: |
-                    {
-                    "serviceName": "${{ parameters.serviceName }}",
-                    "helmReleaseName": "${{ parameters.serviceName }}",
-                    "helmReleaseVersion": "$(appVersion)",
-                    "environment": "${{ deploymentEnv.name}}",
-                    "helmImageAddedToACRTime": "$(helmImageAddedToACRTime)"
-                    }
-                  waitForCompletion: 'true'
           
-          # - job: Post Deployment Tests
-          #   displayName: 'Post Deployment Tests'
-          #   dependsOn: WaitForFluxRelease
-          #   steps:
-          #   - bash: echo "Running Post Deployment Tests"
+          - ${{ if eq(deploymentEnv.name, 'snd1') }}: # Need to add other environments (snd2, snd3, dev1, tst1, pre1, prd1) incrementally as and when the Flux Notifications solution is ready in those environments.
+            - job: WaitForFluxRelease
+              displayName: 'Wait For Flux Release'
+              dependsOn: PublishTo${{ deploymentEnv.name }}
+              pool: server
+              variables:
+                - name: helmImageAddedToACRTime
+                  value: $[ dependencies.PublishTo${{ deploymentEnv.name }}.outputs['PublishTo${{ deploymentEnv.name }}.setAcrImageAddedTime.acrImageAddedTime']]
+                - ${{ if eq(deploymentEnv.name, 'snd1') }}:
+                  - name: callBackServiceConnection
+                    value: 'AZD-ADP-FluxDeploymentApi-DEV1'
+                - ${{ elseif in(deploymentEnv.name, 'snd2', 'snd3') }}:
+                  - name: callBackServiceConnection
+                    value: 'AZD-ADP-FluxDeploymentApi-TST'
+                - ${{ elseif in(deploymentEnv.name, 'dev1', 'tst1', 'pre1', 'prd1') }}:
+                  - name: callBackServiceConnection
+                    value: 'AZD-ADP-FluxDeploymentApi-PRD'
+              timeoutInMinutes: 10
+              steps:            
+                - task: InvokeRESTAPI@1
+                  displayName: 'Call ADO controller api to check If Helmrelease is successfull'
+                  inputs:
+                    serviceConnection: '${{ variables.callBackServiceConnection }}'
+                    urlSuffix: 'api/AdoTask/execute'
+                    method: POST
+                    body: |
+                      {
+                      "serviceName": "${{ parameters.serviceName }}",
+                      "helmReleaseName": "${{ parameters.serviceName }}",
+                      "helmReleaseVersion": "$(appVersion)",
+                      "environment": "${{ deploymentEnv.name}}",
+                      "helmImageAddedToACRTime": "$(helmImageAddedToACRTime)"
+                      }
+                    waitForCompletion: 'true'
+            
+            # - job: Post Deployment Tests
+            #   displayName: 'Post Deployment Tests'
+            #   dependsOn: WaitForFluxRelease
+            #   steps:
+            #   - bash: echo "Running Post Deployment Tests"

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -493,35 +493,3 @@ stages:
                       "helmImageAddedToACRTime": "$(helmImageAddedToACRTime)"
                       }
                     waitForCompletion: 'true'
-
-          
-          # - ${{ if and(eq(deploymentEnv.name, parameters.appTestConfig.postDeployTest.envToTest),not(contains(parameters.stepsToSkip, 'PostDeploymentTests'))) }}:
-          #   - deployment: PostDeploymentTests
-          #     condition:  |
-          #       or(
-          #         eq( variables.IsDefaultBranchBuild, true),
-          #         eq(${{ parameters.deployConfigOnly }}, true),
-          #         and(
-          #           or(
-          #             eq(variables.IsPrBuild, true),
-          #             eq(${{ parameters.deployFromFeature }},true)
-          #           ),
-          #           eq('${{ deploymentEnv.type }}','dev')
-          #         ) 
-          #       )
-          #     - ${{ if eq(deploymentEnv.adoCallBackApiEnabled, True) }}:
-          #       dependsOn: WaitForFluxRelease
-          #       displayName: 'Publish To ${{ deploymentEnv.name }}'
-          #       environment: ${{ deploymentEnv.name }}
-          #       strategy:
-          #         runOnce:
-          #           deploy:          
-          #             steps:
-          #               # - ${{ if ne(parameters.appDeployConfig, '') }}:
-          #               #   - checkout: Self
-          #               #     path: s/ 
-          #               #   - checkout: PipelineCommon
-          #               #     path: s/ADO-Pipeline-Common
-          #                 - template: /templates/steps/post-deployment-tests.yaml
-          #                   parameters:
-          #                     url: "${{ parameters.serviceName }}.${{ deploymentEnv.name }}.${{ parameters.appTestConfig.postDeployTest.domain }}"

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -501,8 +501,8 @@ stages:
                     }
                   waitForCompletion: 'true'
           
-          - job: Post Deployment Tests
-            displayName: 'Post Deployment Tests'
-            dependsOn: WaitForFluxRelease
-            steps:
-            - bash: echo "Running Post Deployment Tests"
+          # - job: Post Deployment Tests
+          #   displayName: 'Post Deployment Tests'
+          #   dependsOn: WaitForFluxRelease
+          #   steps:
+          #   - bash: echo "Running Post Deployment Tests"

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -473,7 +473,7 @@ stages:
             pool: server
             variables:
               - name: helmImageAddedToACRTime
-                value: $[ dependencies.PublishTo${{ deploymentEnv.name }}.outputs['setAcrImageAddedTime.acrImageAddedTime']]
+                value: $[ dependencies.PublishTo${{ deploymentEnv.name }}.outputs['PublishTo${{ deploymentEnv.name }}.setAcrImageAddedTime.acrImageAddedTime']]
               - ${{ if eq(deploymentEnv.name, 'snd1') }}:
                 - name: callBackServiceConnection
                   value: 'AZD-ADP-FluxDeploymentApi-DEV1'

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -493,7 +493,8 @@ stages:
                     "serviceName": "${{ parameters.serviceName }}",
                     "helmReleaseName": "${{ parameters.serviceName }}",
                     "helmReleaseVersion": "$(appVersion)",
-                    "environment": "${{ deploymentEnv.name}}"
+                    "environment": "${{ deploymentEnv.name}}",
+                    "helmImageAddedToACRTime": "$(acrImageAddedTime)"
                     }
                   waitForCompletion: 'true'
           

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -451,6 +451,16 @@ stages:
                             PSHelperDirectory: ${{ variables.PSHelperDirectory }}
                             stepsToSkip: ${{ parameters.stepsToSkip }}
 
+                        - task: PowerShell@2
+                          displayName: 'Set Image added to ACR time used to check Flux Helm Release'   
+                          inputs:
+                            targetType: inline
+                            script: |
+                              Write-Host "##vso[task.setvariable variable=acrImageAddedTime]$(Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ')"
+                            failOnStderr: false
+                            pwsh: true
+                            workingDirectory: '$(Pipeline.Workspace)/s' 
+
                       - ${{ if and(eq(deploymentEnv.name, parameters.appTestConfig.postDeployTest.envToTest),not(contains(parameters.stepsToSkip, 'PostDeploymentTests'))) }}:
                         - template: /templates/steps/post-deployment-tests.yaml
                           parameters:

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -472,7 +472,7 @@ stages:
                     {
                     "serviceName": "${{ parameters.serviceName }}",
                     "helmReleaseName": "${{ parameters.serviceName }}",
-                    "helmReleaseVersion": $(appVersion),
+                    "helmReleaseVersion": "$(appVersion)",
                     "environment": "snd"
                     }
                   waitForCompletion: 'true'

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -461,13 +461,13 @@ stages:
             dependsOn: PublishTo${{ deploymentEnv.name }}
             pool: server
             variables:
-              - ${{ if eq(environment.name, 'snd1') }}:
+              - ${{ if eq(deploymentEnv.name, 'snd1') }}:
                 - name: callBackServiceConnection
                   value: 'AZD-ADP-FluxDeploymentApi-DEV1'
-              - ${{ elseif in(environment.name, 'snd2', 'snd3') }}:
+              - ${{ elseif in(deploymentEnv.name, 'snd2', 'snd3') }}:
                 - name: callBackServiceConnection
                   value: 'AZD-ADP-FluxDeploymentApi-TST'
-              - ${{ elseif in(environment.name, 'dev1', 'tst1', 'pre1', 'prd1') }}:
+              - ${{ elseif in(deploymentEnv.name, 'dev1', 'tst1', 'pre1', 'prd1') }}:
                 - name: callBackServiceConnection
                   value: 'AZD-ADP-FluxDeploymentApi-PRD'
             timeoutInMinutes: 10

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -466,7 +466,7 @@ stages:
                 displayName: 'Call ADO controller api to check If Helmrelease is successfull'
                 inputs:
                   serviceConnection: 'AZD-ADP-FluxDeploymentApi-DEV1'
-                  urlSuffix: 'api/AdoTask'
+                  urlSuffix: 'api/AdoTask/execute'
                   method: POST
                   body: |
                     {

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -490,7 +490,7 @@ stages:
                 - task: InvokeRESTAPI@1
                   displayName: 'Call ADO controller api to check If Helmrelease is successfull'
                   inputs:
-                    serviceConnection: 'AZD-ADP-FluxDeploymentApi-${{ deploymentEnv.adoCallBackApiEnabledEnv }}'
+                    serviceConnection: 'AZD-ADP-AdoCallbackApi-${{ deploymentEnv.adoCallBackApiEnabledEnv }}'
                     urlSuffix: 'api/AdoTask/execute'
                     method: POST
                     body: |

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -452,11 +452,12 @@ stages:
                             stepsToSkip: ${{ parameters.stepsToSkip }}
 
                       - task: PowerShell@2
-                        displayName: 'Set Image added to ACR time used to check Flux Helm Release'   
+                        displayName: 'Set Image added to ACR time used to check Flux Helm Release'
+                        name: setAcrImageAddedTime
                         inputs:
                           targetType: inline
                           script: |
-                            Write-Host "##vso[task.setvariable variable=acrImageAddedTime]$(Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ')"
+                            Write-Host "##vso[task.setvariable variable=acrImageAddedTime;isOutput=true;]$(Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ')"
                           failOnStderr: false
                           pwsh: true
                           workingDirectory: '$(Pipeline.Workspace)/s' 
@@ -471,6 +472,8 @@ stages:
             dependsOn: PublishTo${{ deploymentEnv.name }}
             pool: server
             variables:
+              - name: helmImageAddedToACRTime
+                value: $[ dependencies.PublishTo${{ deploymentEnv.name }}.outputs['setAcrImageAddedTime.acrImageAddedTime']]
               - ${{ if eq(deploymentEnv.name, 'snd1') }}:
                 - name: callBackServiceConnection
                   value: 'AZD-ADP-FluxDeploymentApi-DEV1'
@@ -494,11 +497,12 @@ stages:
                     "helmReleaseName": "${{ parameters.serviceName }}",
                     "helmReleaseVersion": "$(appVersion)",
                     "environment": "${{ deploymentEnv.name}}",
-                    "helmImageAddedToACRTime": "$(acrImageAddedTime)"
+                    "helmImageAddedToACRTime": "$(helmImageAddedToACRTime)"
                     }
                   waitForCompletion: 'true'
           
-          - job: PostDeploymentTests
+          - job: Post Deployment Tests
+            displayName: 'Post Deployment Tests'
             dependsOn: WaitForFluxRelease
             steps:
             - bash: echo "Running Post Deployment Tests"

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -460,12 +460,22 @@ stages:
             displayName: 'Wait For Flux Release'
             dependsOn: PublishTo${{ deploymentEnv.name }}
             pool: server
+            variables:
+              - ${{ if eq(environment.name, 'snd1') }}:
+                - name: callBackServiceConnection
+                  value: 'AZD-ADP-FluxDeploymentApi-DEV1'
+              - ${{ elseif in(environment.name, 'snd2', 'snd3') }}:
+                - name: callBackServiceConnection
+                  value: 'AZD-ADP-FluxDeploymentApi-TST'
+              - ${{ elseif in(environment.name, 'dev1', 'tst1', 'pre1', 'prd1') }}:
+                - name: callBackServiceConnection
+                  value: 'AZD-ADP-FluxDeploymentApi-PRD'
             timeoutInMinutes: 10
             steps:            
               - task: InvokeRESTAPI@1
                 displayName: 'Call ADO controller api to check If Helmrelease is successfull'
                 inputs:
-                  serviceConnection: 'AZD-ADP-FluxDeploymentApi-DEV1'
+                  serviceConnection: '${{ variables.callBackServiceConnection }}'
                   urlSuffix: 'api/AdoTask/execute'
                   method: POST
                   body: |

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -497,7 +497,7 @@ stages:
                       "serviceName": "${{ parameters.serviceName }}",
                       "helmReleaseName": "${{ parameters.serviceName }}",
                       "helmReleaseVersion": "$(appVersion)",
-                      "environment": "${{ deploymentEnv.name}}",
+                      "environment": "${{ deploymentEnv.name }}",
                       "helmImageAddedToACRTime": "$(helmImageAddedToACRTime)"
                       }
                     waitForCompletion: 'true'

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -481,7 +481,7 @@ stages:
                 - task: InvokeRESTAPI@1
                   displayName: 'Call ADO controller api to check If Helmrelease is successfull'
                   inputs:
-                    serviceConnection: 'AZD-ADP-AdoCallbackApi-${{ deploymentEnv.adoCallBackApiEnabledEnv }}'
+                    serviceConnection: 'AZD-ADP-AdoCallbackApi-${{ deploymentEnv.adoCallBackApiEnv }}'
                     urlSuffix: 'api/AdoTask/execute'
                     method: POST
                     body: |

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -462,7 +462,7 @@ stages:
                             failOnStderr: false
                             pwsh: true
                             workingDirectory: '$(Pipeline.Workspace)/s' 
-
+          
                       - ${{ if and(eq(deploymentEnv.name, parameters.appTestConfig.postDeployTest.envToTest),not(contains(parameters.stepsToSkip, 'PostDeploymentTests'))) }}:
                         - template: /templates/steps/post-deployment-tests.yaml
                           parameters:
@@ -493,3 +493,35 @@ stages:
                       "helmImageAddedToACRTime": "$(helmImageAddedToACRTime)"
                       }
                     waitForCompletion: 'true'
+
+          
+          # - ${{ if and(eq(deploymentEnv.name, parameters.appTestConfig.postDeployTest.envToTest),not(contains(parameters.stepsToSkip, 'PostDeploymentTests'))) }}:
+          #   - deployment: PostDeploymentTests
+          #     condition:  |
+          #       or(
+          #         eq( variables.IsDefaultBranchBuild, true),
+          #         eq(${{ parameters.deployConfigOnly }}, true),
+          #         and(
+          #           or(
+          #             eq(variables.IsPrBuild, true),
+          #             eq(${{ parameters.deployFromFeature }},true)
+          #           ),
+          #           eq('${{ deploymentEnv.type }}','dev')
+          #         ) 
+          #       )
+          #     - ${{ if eq(deploymentEnv.adoCallBackApiEnabled, True) }}:
+          #       dependsOn: WaitForFluxRelease
+          #       displayName: 'Publish To ${{ deploymentEnv.name }}'
+          #       environment: ${{ deploymentEnv.name }}
+          #       strategy:
+          #         runOnce:
+          #           deploy:          
+          #             steps:
+          #               # - ${{ if ne(parameters.appDeployConfig, '') }}:
+          #               #   - checkout: Self
+          #               #     path: s/ 
+          #               #   - checkout: PipelineCommon
+          #               #     path: s/ADO-Pipeline-Common
+          #                 - template: /templates/steps/post-deployment-tests.yaml
+          #                   parameters:
+          #                     url: "${{ parameters.serviceName }}.${{ deploymentEnv.name }}.${{ parameters.appTestConfig.postDeployTest.domain }}"

--- a/templates/pipelines/common-infrastructure-deploy.yaml
+++ b/templates/pipelines/common-infrastructure-deploy.yaml
@@ -334,6 +334,10 @@ stages:
                                       scriptsList: ${{ deployment.postDeployScriptsList }}
                                       variables: ${{ variables }}
                               - ${{ if eq(deployment.type, 'script') }}:
+                                - template: /templates/steps/initialize.yaml
+                                  parameters:
+                                    tokenReplaceLocations: ${{ parameters.filePathsForTransform }}
+                                    tokenReplaceEscapeConfig: ${{ parameters.tokenReplaceEscapeConfig }}
                                 - template: /templates/steps/powershell.yaml
                                   parameters:
                                     azureResourceManagerConnection: "${{ coalesce(variables[deployment.serviceConnectionVariableName], env.serviceConnection) }}"


### PR DESCRIPTION
# **What this PR does / why we need it**:
Added task to capture the time after the completion of the Helm publish to Azure Container Registry.  The time is then used in the WaitForFluxRelease job to determine if the release has successfully deployed.

The task and job can be enabled by the calling pipeline 'adp-pipeline-common' by setting the  adoCallBackApiEnabled parameter to True.  This is initially set to False for all environments, until we have the solution deployed to all environments and Authorization is added to the callbak api.

AB#353142

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
