### PR TITLE
353142: Add accept header "Accept": "application/json"

### DIFF
--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -521,7 +521,8 @@ stages:
                       "TimelineId": "$(system.TimelineId)",
                       "TaskInstanceId": "$(system.TaskInstanceId)",
                       "AuthToken": "$(system.AccessToken)",
-                      "Authorization": "$(token)"
+                      "Authorization": "$(token)",
+                      "Accept": "application/json"
                       }
                     body: |
                       {


### PR DESCRIPTION
# **What this PR does / why we need it**:
Azure Frontdoor WAF log have highlighted we should be adding the ACCEPT header in our requests to the ado-callback-api.  This change adds the ACCEPT header as per the recommendation.

# **Special notes for your reviewer**
*Any specific actions or notes on review?*
Tested in SND1 and SND3 against a couple of demo apps - links in testing section below and we can't see the message in the WAF logs for these 2 runs since adding the header

[AB#353142](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/353142)

# Testing
*Any relevant testing information and pipeline runs.*
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=553052&view=results

https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=553052&view=results


# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [ x Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
