### PR TITLE
AB#379517 Reintegrate Post-Deployment Tests into the Pipeline

### DIFF
--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -536,6 +536,7 @@ stages:
 
           - deployment: PostDeploymentTests${{ deploymentEnv.name }}
             displayName: 'Run Post Deployment Tests in ${{ deploymentEnv.name }}'
+            dependsOn: WaitForFluxRelease
             environment: ${{ deploymentEnv.name }}
             strategy:
               runOnce:

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -534,15 +534,15 @@ stages:
                       }
                     waitForCompletion: 'true'
 
-          - deployment: PostDeploymentTests${{ deploymentEnv.name }}
-            displayName: 'Run Post Deployment Tests in ${{ deploymentEnv.name }}'
-            dependsOn: WaitForFluxRelease
-            environment: ${{ deploymentEnv.name }}
-            strategy:
-              runOnce:
-                deploy:          
-                  steps:
-                    - ${{ if and(eq(deploymentEnv.name, parameters.appTestConfig.postDeployTest.envToTest),not(contains(parameters.stepsToSkip, 'PostDeploymentTests'))) }}:
+          - ${{ if and(eq(deploymentEnv.name, parameters.appTestConfig.postDeployTest.envToTest),not(contains(parameters.stepsToSkip, 'PostDeploymentTests'))) }}:
+            - deployment: PostDeploymentTests${{ deploymentEnv.name }}
+              displayName: 'Run Post Deployment Tests in ${{ deploymentEnv.name }}'
+              dependsOn: WaitForFluxRelease
+              environment: ${{ deploymentEnv.name }}
+              strategy:
+                runOnce:
+                  deploy:          
+                    steps:
                       - template: /templates/steps/post-deployment-tests.yaml
                         parameters:
                           url: "${{ parameters.serviceName }}.${{ deploymentEnv.name }}.${{ parameters.appTestConfig.postDeployTest.domain }}"

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -536,7 +536,7 @@ stages:
 
           - ${{ if and(eq(deploymentEnv.name, parameters.appTestConfig.postDeployTest.envToTest),not(contains(parameters.stepsToSkip, 'PostDeploymentTests'))) }}:
             - deployment: PostDeploymentTests${{ deploymentEnv.name }}
-              displayName: 'Run Post Deployment Tests in ${{ deploymentEnv.name }}'
+              displayName: 'Post Deployment Tests'
               dependsOn: WaitForFluxRelease
               environment: ${{ deploymentEnv.name }}
               strategy:

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -543,6 +543,13 @@ stages:
                 runOnce:
                   deploy:          
                     steps:
+                      - checkout: self
+                        path: s/source
+                        persistCredentials: true
+
+                      - checkout: PipelineCommon
+                        path: s/ADO-Pipeline-Common
+                        
                       - template: /templates/steps/post-deployment-tests.yaml
                         parameters:
                           url: "${{ parameters.serviceName }}.${{ deploymentEnv.name }}.${{ parameters.appTestConfig.postDeployTest.domain }}"

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -534,7 +534,7 @@ stages:
                       }
                     waitForCompletion: 'true'
 
-          - ${{ if and(eq(deploymentEnv.name, parameters.appTestConfig.postDeployTest.envToTest),not(contains(parameters.stepsToSkip, 'PostDeploymentTests'))) }}:
+          - ${{ if and(eq(deploymentEnv.name, parameters.appTestConfig.postDeployTest.envToTest), not(contains(parameters.stepsToSkip, 'PostDeploymentTests')), eq(deploymentEnv.adoCallBackApiEnabled, True)) }}:
             - deployment: PostDeploymentTests${{ deploymentEnv.name }}
               displayName: 'Post Deployment Tests'
               dependsOn: WaitForFluxRelease

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -487,11 +487,6 @@ stages:
                             pwsh: true
                             workingDirectory: '$(Pipeline.Workspace)/s'     
           
-                      # - ${{ if and(eq(deploymentEnv.name, parameters.appTestConfig.postDeployTest.envToTest),not(contains(parameters.stepsToSkip, 'PostDeploymentTests'))) }}:
-                      #   - template: /templates/steps/post-deployment-tests.yaml
-                      #     parameters:
-                      #       url: "${{ parameters.serviceName }}.${{ deploymentEnv.name }}.${{ parameters.appTestConfig.postDeployTest.domain }}"
-          
           - ${{ if and(eq(deploymentEnv.adoCallBackApiEnabled, True), eq(parameters.deployConfigOnly, false )) }}:
             - job: WaitForFluxRelease
               displayName: 'Wait For Flux Release'

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -492,7 +492,7 @@ stages:
                       #     parameters:
                       #       url: "${{ parameters.serviceName }}.${{ deploymentEnv.name }}.${{ parameters.appTestConfig.postDeployTest.domain }}"
           
-          - ${{ if eq(deploymentEnv.adoCallBackApiEnabled, True) }}:
+          - ${{ if and(eq(deploymentEnv.adoCallBackApiEnabled, True), eq(parameters.deployConfigOnly, false )) }}:
             - job: WaitForFluxRelease
               displayName: 'Wait For Flux Release'
               dependsOn: PublishTo${{ deploymentEnv.name }}
@@ -534,7 +534,7 @@ stages:
                       }
                     waitForCompletion: 'true'
 
-          - ${{ if and(eq(deploymentEnv.name, parameters.appTestConfig.postDeployTest.envToTest), not(contains(parameters.stepsToSkip, 'PostDeploymentTests')), eq(deploymentEnv.adoCallBackApiEnabled, True)) }}:
+          - ${{ if and(eq(deploymentEnv.name, parameters.appTestConfig.postDeployTest.envToTest), not(contains(parameters.stepsToSkip, 'PostDeploymentTests')), eq(deploymentEnv.adoCallBackApiEnabled, True), eq(parameters.deployConfigOnly, false )) }}:
             - deployment: PostDeploymentTests${{ deploymentEnv.name }}
               displayName: 'Post Deployment Tests'
               dependsOn: WaitForFluxRelease

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -534,3 +534,14 @@ stages:
                       }
                     waitForCompletion: 'true'
 
+          - deployment: PostDeploymentTests${{ deploymentEnv.name }}
+            displayName: 'Run Post Deployment Tests in ${{ deploymentEnv.name }}'
+            environment: ${{ deploymentEnv.name }}
+            strategy:
+              runOnce:
+                deploy:          
+                  steps:
+                    - ${{ if and(eq(deploymentEnv.name, parameters.appTestConfig.postDeployTest.envToTest),not(contains(parameters.stepsToSkip, 'PostDeploymentTests'))) }}:
+                      - template: /templates/steps/post-deployment-tests.yaml
+                        parameters:
+                          url: "${{ parameters.serviceName }}.${{ deploymentEnv.name }}.${{ parameters.appTestConfig.postDeployTest.domain }}"

--- a/templates/pipelines/common-app-ci.yaml
+++ b/templates/pipelines/common-app-ci.yaml
@@ -542,14 +542,12 @@ stages:
               strategy:
                 runOnce:
                   deploy:          
-                    steps:
-                      - checkout: self
-                        path: s/source
-                        persistCredentials: true
-
+                    steps:                      
+                      - checkout: Self
+                        path: s/ 
                       - checkout: PipelineCommon
                         path: s/ADO-Pipeline-Common
-                        
+
                       - template: /templates/steps/post-deployment-tests.yaml
                         parameters:
                           url: "${{ parameters.serviceName }}.${{ deploymentEnv.name }}.${{ parameters.appTestConfig.postDeployTest.domain }}"


### PR DESCRIPTION
# **What this PR does / why we need it**:
This PR is to move the Post Deployment tests ( commented out section ) to a new job which runs after the Flux deployment has completed.  There's also an additional condition to not run the tests when it's a config only change as it was doing previously.

[AB#379517](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/379517)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=558105&view=results

![image](https://github.com/DEFRA/ado-pipeline-common/assets/39670555/1d9dbb98-0d67-446d-8956-cdac1e0e88db)


# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
