### PR TITLE
384224: Bug fix for no variable groups in pre check for app config import

### DIFF
--- a/templates/powershell/build/PreImportAppConfigCheck.ps1
+++ b/templates/powershell/build/PreImportAppConfigCheck.ps1
@@ -48,7 +48,7 @@ param(
     [string]$AppConfigModuleDirectory
 )
 
-function Test-AppConfigSecretValue{
+function Test-AppConfigSecretValue {
     param(
         [Parameter(Mandatory, ValueFromPipeline)]
         [AppConfigEntry]$ConfigSecret,
@@ -83,10 +83,10 @@ function Test-AppConfigSecretValue{
             Write-Debug "${functionName}:Key Vault Secret Scope:$scope"
 
             Write-Debug "${functionName}:Checking role assignment for the secret $secretName in the Key Vault $KeyVaultName for the service $ServiceName"
-            $role = Get-AzRoleAssignment -Scope $scope -RoleDefinitionName 'Key Vault Secrets User' | Where-Object { $_.DisplayName -like '*'+$ServiceName }
+            $role = Get-AzRoleAssignment -Scope $scope -RoleDefinitionName 'Key Vault Secrets User' | Where-Object { $_.DisplayName -like '*' + $ServiceName }
             if (!$role) {
                 $warningObject = New-Object PSObject -Property @{ 
-                    Type = "warning" 
+                    Type    = "warning" 
                     Message = "Role assignment for the secret $secretName in the Key Vault $KeyVaultName does not exist. The application $ServiceName will not function correctly without this role." 
                 }
                 Write-Output $warningObject
@@ -94,7 +94,7 @@ function Test-AppConfigSecretValue{
         } 
         else {
             $errorObject = New-Object PSObject -Property @{ 
-                Type = "error" 
+                Type    = "error" 
                 Message = "Secret $secretName not found in the Key Vault $KeyVaultName." 
             }
             Write-Output $errorObject
@@ -136,6 +136,11 @@ try {
     Import-Module $PSHelperDirectory -Force
     Import-Module $AppConfigModuleDirectory -Force
 
+    #If there are no variable groups for given service the AdoVariableNames value will be "$(secretVariableNamesJson)"
+    if ($AdoVariableNames.Contains("secretVariableNamesJson")) {
+        $AdoVariableNames = "[]"
+    }
+
     Set-AzContext -SubscriptionId $SubscriptionId | Out-Null
 
     if (Test-Path $ConfigFilePath -PathType Leaf) {
@@ -148,7 +153,7 @@ try {
             $_.IsKeyVault() 
         } | Test-AppConfigSecretValue -KeyVaultName $KeyVaultName -ServiceName $ServiceName -AdoVariableNames $AdoVariableNames
 
-        if($issues) {
+        if ($issues) {
             $issues | ForEach-Object {
                 $propertyNames = $_.PSObject.Properties.Name
                 if ($propertyNames -contains 'Type' -and $propertyNames -contains 'Message') {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
This PR contains the bug fix for no variable group vars in pre check for app config import in common app CI pipeline
[AB#384224](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/384224)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
Tested for apps with and without variable groups.
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=566294&view=results
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=566325&view=results

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
